### PR TITLE
no-std support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -182,7 +182,6 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "curve25519-dalek-derive",
- "digest",
  "fiat-crypto",
  "rand_core",
  "rustc_version",

--- a/fuzzy-message-detection/Cargo.toml
+++ b/fuzzy-message-detection/Cargo.toml
@@ -5,13 +5,14 @@ edition = "2021"
 
 [dependencies]
 curve25519-dalek = {version = "4.1.3", default-features = false, features = ["digest", "rand_core"]}
-rand_core = { version = "0.6", default-features = false, features = ["getrandom"] }
+rand_core = { version = "0.6", default-features = false }
 serde = { version = "1.0.217", default-features = false, features = ["derive"], optional = true }
 sha2 = "0.10.8"
 subtle = {  version = "2.6.1" , default-features = false}
 
 [dev-dependencies]
 criterion = "0.3"
+rand_core = { version = "0.6", default-features = false , features = ["getrandom"]}
 
 [features]
 serde = ["dep:serde", "curve25519-dalek/serde"]

--- a/fuzzy-message-detection/Cargo.toml
+++ b/fuzzy-message-detection/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 curve25519-dalek = {version = "4.1.3", default-features = false, features = ["digest", "rand_core"]}
 rand_core = { version = "0.6", default-features = false, features = ["getrandom"] }
-serde = { version = "1.0.217", features = ["derive"], optional = true }
+serde = { version = "1.0.217", default-features = false, features = ["derive"], optional = true }
 sha2 = "0.10.8"
 subtle = {  version = "2.6.1" , default-features = false}
 

--- a/fuzzy-message-detection/Cargo.toml
+++ b/fuzzy-message-detection/Cargo.toml
@@ -4,10 +4,10 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-curve25519-dalek = {version = "4.1.3", default-features = false, features = ["digest", "rand_core"]}
+curve25519-dalek = {version = "4.1.3", default-features = false, features = ["rand_core"]}
 rand_core = { version = "0.6", default-features = false }
 serde = { version = "1.0.217", default-features = false, features = ["derive"], optional = true }
-sha2 = "0.10.8"
+sha2 = { version = "0.10.8", default-features = false }
 subtle = {  version = "2.6.1" , default-features = false}
 
 [dev-dependencies]

--- a/fuzzy-message-detection/Cargo.toml
+++ b/fuzzy-message-detection/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 curve25519-dalek = {version = "4.1.3", default-features = false, features = ["rand_core"]}
 rand_core = { version = "0.6", default-features = false }
 serde = { version = "1.0.217", default-features = false, features = ["derive"], optional = true }
-sha2 = { version = "0.10.8", default-features = false }
+sha2 = { version = "0.10.8", default-features = false, features = ["force-soft"] }
 subtle = {  version = "2.6.1" , default-features = false}
 
 [dev-dependencies]

--- a/fuzzy-message-detection/src/fmd2.rs
+++ b/fuzzy-message-detection/src/fmd2.rs
@@ -1,4 +1,7 @@
 //! The FMD2 scheme.
+
+use alloc::vec::Vec;
+
 use curve25519_dalek::{
     constants::RISTRETTO_BASEPOINT_POINT, ristretto::RistrettoPoint, scalar::Scalar,
 };

--- a/fuzzy-message-detection/src/fmd2_generic.rs
+++ b/fuzzy-message-detection/src/fmd2_generic.rs
@@ -216,8 +216,9 @@ fn hash_to_flag_ciphertext_bit(
 fn hash_flag_ciphertexts(u: &RistrettoPoint, bit_ciphertexts: &[bool]) -> Scalar {
     let mut m_bytes = u.compress().to_bytes().to_vec();
     m_bytes.extend_from_slice(&GenericFlagCiphertexts::to_bytes(bit_ciphertexts));
-
-    Scalar::hash_from_bytes::<Sha512>(&m_bytes)
+    let mut hasher = Sha512::default();
+    Digest::update(&mut hasher, &m_bytes);
+    Scalar::from_bytes_mod_order_wide(&hasher.finalize().into())
 }
 
 #[cfg(test)]

--- a/fuzzy-message-detection/src/fmd2_generic.rs
+++ b/fuzzy-message-detection/src/fmd2_generic.rs
@@ -1,6 +1,7 @@
 // An internal generic implementation of the FMD2 flag and detect algorithms.
 // It uses arbitrary basepoints for ElGamal encryption and the Chamaleon Hash.
-use std::collections::BTreeSet;
+use alloc::collections::BTreeSet;
+use alloc::vec::Vec;
 
 use curve25519_dalek::{
     constants::RISTRETTO_BASEPOINT_POINT, ristretto::RistrettoPoint, scalar::Scalar,

--- a/fuzzy-message-detection/src/lib.rs
+++ b/fuzzy-message-detection/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(not(test), no_std)]
+
 extern crate alloc;
 
 use rand_core::{CryptoRng, RngCore};


### PR DESCRIPTION
A lot of the tech out there for deploying this to enclaves require `no-std`. Furthermore, I was testing using this as a library in a custom OS. This limits some standard hardware assumptions made by some of the crypto crates (curve25591-dalek and sha2), especially regarding things like SIMD.  This PR fixes those issues.