### PR TITLE
Enrique/filter combine

### DIFF
--- a/fuzzy-message-detection/src/combiner.rs
+++ b/fuzzy-message-detection/src/combiner.rs
@@ -1,0 +1,52 @@
+use alloc::vec;
+
+/// Combines multiple filtered messages into a smaller collection
+/// of messages.
+pub struct FilterCombiner;
+
+impl FilterCombiner {
+    /// Combines messages whose flags have been filtered ([detected](crate::FmdScheme::detect)) with
+    /// different detection keys.
+    pub fn combine<T: Eq + Clone>(filtered_messages: &[vec::Vec<T>]) -> vec::Vec<T> {
+        if filtered_messages.is_empty() {
+            return vec![];
+        }
+        let mut result = vec![];
+        filtered_messages[0].iter().for_each(|msg| {
+            if filtered_messages[1..]
+                .iter()
+                .all(|list| list.contains(&msg))
+            {
+                result.push(msg.clone());
+            }
+        });
+        result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::FilterCombiner;
+
+    #[test]
+    fn test_filter_combine() -> () {
+        // interesects correctly
+        let mut combined = FilterCombiner::combine(&[
+            vec![0, 1, 2, 3, 4, 5],
+            vec![1, 2, 3, 4, 5],
+            vec![0, 1, 2, 3],
+            vec![2, 3, 4, 5, 6],
+        ]);
+        assert_eq!(combined, vec![2, 3]);
+
+        // combining disjoint messages yields empty
+        combined = FilterCombiner::combine(&[vec![0, 1, 2], vec![3, 4]]);
+        assert_eq!(true, combined.is_empty());
+
+        // combining an empty vector yields empty
+        combined = FilterCombiner::combine(&[vec![0, 1, 2], vec![]]);
+        assert_eq!(true, combined.is_empty());
+
+        ()
+    }
+}

--- a/fuzzy-message-detection/src/lib.rs
+++ b/fuzzy-message-detection/src/lib.rs
@@ -5,9 +5,11 @@ extern crate alloc;
 use alloc::vec::Vec;
 use rand_core::{CryptoRng, RngCore};
 
+pub(crate) mod combiner;
 pub mod fmd2;
 pub(crate) mod fmd2_generic;
 pub mod fmd2_poly;
+pub use crate::combiner::FilterCombiner;
 pub use crate::fmd2_generic::{DetectionKey, SecretKey};
 /// A trait for a Fuzzy Message Detection (FMD) scheme with multi-extraction.
 ///


### PR DESCRIPTION
Implements the filter combine described in Section 3.4.2 of the ART report. 
* Combining filtered messages is just taking their intersection. 

Resolves #24 