### PR TITLE
compressed compact public key and serializations

### DIFF
--- a/fuzzy-message-detection/src/fmd2_generic.rs
+++ b/fuzzy-message-detection/src/fmd2_generic.rs
@@ -148,6 +148,8 @@ impl Default for ChamaleonHashBasepoint {
 }
 
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+
 pub(crate) struct GenericFlagCiphertexts {
     pub(crate) basepoint_ch: RistrettoPoint, // Basepoint for the Chamaleon Hash.
     pub(crate) u: RistrettoPoint,


### PR DESCRIPTION
* Adds a compressed representation of compact public keys. The basepoint is dropped.
* (De)serialization for:
  * Compressed compact public keys
  * Flag ciphertexts 
 
Resolves #26.