### PR TITLE
Get compact public key from compact secret key

### DIFF
--- a/polyfuzzy/src/fmd2_compact/mod.rs
+++ b/polyfuzzy/src/fmd2_compact/mod.rs
@@ -17,12 +17,8 @@ use crate::{
 pub struct CompactSecretKey(Polynomial);
 
 impl CompactSecretKey {
-    pub fn evaluate<EK>(&self, values: &[Scalar]) -> Vec<Scalar>
-    {
-        self
-            .0
-            .evaluate(values)
-            .results
+    pub fn evaluate<EK>(&self, values: &[Scalar]) -> Vec<Scalar> {
+        self.0.evaluate(values).results
     }
 }
 

--- a/polyfuzzy/src/fmd2_compact/mod.rs
+++ b/polyfuzzy/src/fmd2_compact/mod.rs
@@ -16,6 +16,16 @@ use crate::{
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct CompactSecretKey(Polynomial);
 
+impl CompactSecretKey {
+    pub fn evaluate<EK>(&self, values: &[Scalar]) -> Vec<Scalar>
+    {
+        self
+            .0
+            .evaluate(values)
+            .results
+    }
+}
+
 /// An encoded polynomial over Ristretto. t+2 points.
 /// The first point is the basepoint, the remaining
 /// t+1 points the encoded coefficients.
@@ -69,7 +79,7 @@ impl MultiFmd2CompactScheme {
     /// Public scalars default to 1,...,γ in Z_q.
     pub fn new(gamma: usize, threshold: usize) -> Self {
         let mut public_scalars = Vec::new();
-        let mut scalar = Scalar::ONE + Scalar::ONE;
+        let mut scalar = Scalar::ONE;
         for _i in 0..gamma {
             // Safely assume γ << q
             public_scalars.push(scalar);
@@ -151,21 +161,6 @@ impl KeyExpansion<CompactSecretKey, CompactPublicKey, FmdPublicKey> for MultiFmd
         let encoded_evaluations = parent_pk.0.evaluate(&self.public_scalars);
 
         FmdPublicKey(encoded_evaluations)
-    }
-
-    fn encryption_key<EK>(&self, parent_sk: &CompactSecretKey) -> EK
-    where
-        EK: From<[u8; 32]>,
-    {
-        parent_sk
-            .0
-            .evaluate(&[Scalar::ONE])
-            .results
-            .into_iter()
-            .next()
-            .unwrap()
-            .to_bytes()
-            .into()
     }
 }
 

--- a/polyfuzzy/src/fmd2_compact/mod.rs
+++ b/polyfuzzy/src/fmd2_compact/mod.rs
@@ -17,11 +17,7 @@ use crate::{
 pub struct CompactSecretKey(Polynomial);
 
 impl CompactSecretKey {
-    pub fn evaluate(&self, values: &[Scalar]) -> Vec<Scalar> {
-        self.0.evaluate(values).results
-    }
-
-    /// Get the public key counterpart of this key
+     /// Get the public key counterpart of this key
     /// with standard basepoint
     pub fn public_key(&self) -> CompactPublicKey {
         CompactPublicKey(self.0.encode(&RISTRETTO_BASEPOINT_POINT))

--- a/polyfuzzy/src/fmd2_compact/mod.rs
+++ b/polyfuzzy/src/fmd2_compact/mod.rs
@@ -17,7 +17,7 @@ use crate::{
 pub struct CompactSecretKey(Polynomial);
 
 impl CompactSecretKey {
-     /// Get the public key counterpart of this key
+    /// Get the public key counterpart of this key
     /// with standard basepoint
     pub fn public_key(&self) -> CompactPublicKey {
         CompactPublicKey(self.0.encode(&RISTRETTO_BASEPOINT_POINT))

--- a/polyfuzzy/src/fmd2_compact/mod.rs
+++ b/polyfuzzy/src/fmd2_compact/mod.rs
@@ -69,7 +69,7 @@ impl MultiFmd2CompactScheme {
     /// Public scalars default to 1,...,γ in Z_q.
     pub fn new(gamma: usize, threshold: usize) -> Self {
         let mut public_scalars = Vec::new();
-        let mut scalar = Scalar::ONE;
+        let mut scalar = Scalar::ONE + Scalar::ONE;
         for _i in 0..gamma {
             // Safely assume γ << q
             public_scalars.push(scalar);
@@ -151,6 +151,21 @@ impl KeyExpansion<CompactSecretKey, CompactPublicKey, FmdPublicKey> for MultiFmd
         let encoded_evaluations = parent_pk.0.evaluate(&self.public_scalars);
 
         FmdPublicKey(encoded_evaluations)
+    }
+
+    fn encryption_key<EK>(&self, parent_sk: &CompactSecretKey) -> EK
+    where
+        EK: From<[u8; 32]>,
+    {
+        parent_sk
+            .0
+            .evaluate(&[Scalar::ONE])
+            .results
+            .into_iter()
+            .next()
+            .unwrap()
+            .to_bytes()
+            .into()
     }
 }
 

--- a/polyfuzzy/src/fmd2_compact/mod.rs
+++ b/polyfuzzy/src/fmd2_compact/mod.rs
@@ -20,6 +20,12 @@ impl CompactSecretKey {
     pub fn evaluate(&self, values: &[Scalar]) -> Vec<Scalar> {
         self.0.evaluate(values).results
     }
+
+    /// Get the public key counterpart of this key
+    /// with standard basepoint
+    pub fn public_key(&self) -> CompactPublicKey {
+        CompactPublicKey(self.0.encode(&RISTRETTO_BASEPOINT_POINT))
+    }
 }
 
 /// An encoded polynomial over Ristretto. t+2 points.

--- a/polyfuzzy/src/fmd2_compact/mod.rs
+++ b/polyfuzzy/src/fmd2_compact/mod.rs
@@ -19,7 +19,7 @@ pub struct CompactSecretKey(Polynomial);
 impl CompactSecretKey {
     /// Get the public key counterpart of this key
     /// with standard basepoint
-    pub fn public_key(&self) -> CompactPublicKey {
+    pub fn master_public_key(&self) -> CompactPublicKey {
         CompactPublicKey(self.0.encode(&RISTRETTO_BASEPOINT_POINT))
     }
 }

--- a/polyfuzzy/src/fmd2_compact/mod.rs
+++ b/polyfuzzy/src/fmd2_compact/mod.rs
@@ -17,7 +17,7 @@ use crate::{
 pub struct CompactSecretKey(Polynomial);
 
 impl CompactSecretKey {
-    pub fn evaluate<EK>(&self, values: &[Scalar]) -> Vec<Scalar> {
+    pub fn evaluate(&self, values: &[Scalar]) -> Vec<Scalar> {
         self.0.evaluate(values).results
     }
 }

--- a/polyfuzzy/src/lib.rs
+++ b/polyfuzzy/src/lib.rs
@@ -45,6 +45,10 @@ pub trait KeyExpansion<SK, PK, DPK>: FmdKeyGen<SK, PK> {
     fn expand_keypair(&self, parent_sk: &SK, parent_pk: &PK) -> (FmdSecretKey, DPK);
 
     fn expand_public_key(&self, parent_pk: &PK) -> DPK;
+
+    fn encryption_key<EK>(&self, parent_sk: &SK) -> EK
+    where
+        EK: From<[u8; 32]>;
 }
 
 /// A trait to randomize public keys.

--- a/polyfuzzy/src/lib.rs
+++ b/polyfuzzy/src/lib.rs
@@ -45,10 +45,6 @@ pub trait KeyExpansion<SK, PK, DPK>: FmdKeyGen<SK, PK> {
     fn expand_keypair(&self, parent_sk: &SK, parent_pk: &PK) -> (FmdSecretKey, DPK);
 
     fn expand_public_key(&self, parent_pk: &PK) -> DPK;
-
-    fn encryption_key<EK>(&self, parent_sk: &SK) -> EK
-    where
-        EK: From<[u8; 32]>;
 }
 
 /// A trait to randomize public keys.


### PR DESCRIPTION


This PR adds a convenience method to get the compact publc key from the compact secret key using the standard basepoint. This is mostly a UX improvement for the Kassandra client so that users do not need to pass both values in.