### PR TITLE
Optimize flag detection on the polynomial scheme

### DIFF
--- a/polyfuzzy/src/fmd2.rs
+++ b/polyfuzzy/src/fmd2.rs
@@ -10,7 +10,9 @@ use rand_core::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    fmd2_generic::{ChamaleonHashBasepoint, GenericFlagCiphertexts, GenericFmdPublicKey},
+    fmd2_generic::{
+        ChamaleonHashBasepoint, CiphertextBits, GenericFlagCiphertexts, GenericFmdPublicKey,
+    },
     DetectionKey, FmdKeyGen, FmdSecretKey, MultiFmdScheme,
 };
 
@@ -95,7 +97,7 @@ impl MultiFmdScheme<FmdPublicKey, FlagCiphertexts> for Fmd2MultikeyScheme {
         GenericFlagCiphertexts::generate_flag(&gpk, &ChamaleonHashBasepoint::default(), rng).into()
     }
 
-    fn detect(&self, detection_key: &DetectionKey, flag_ciphers: &FlagCiphertexts) -> bool {
+    fn detect(&mut self, detection_key: &DetectionKey, flag_ciphers: &FlagCiphertexts) -> bool {
         let gfc = GenericFlagCiphertexts::new(
             &RISTRETTO_BASEPOINT_POINT,
             &flag_ciphers.u,
@@ -103,6 +105,6 @@ impl MultiFmdScheme<FmdPublicKey, FlagCiphertexts> for Fmd2MultikeyScheme {
             &flag_ciphers.c,
         );
 
-        detection_key.detect(&gfc)
+        detection_key.detect(&mut CiphertextBits::new(), &gfc)
     }
 }

--- a/polyfuzzy/src/fmd2_compact/mod.rs
+++ b/polyfuzzy/src/fmd2_compact/mod.rs
@@ -255,6 +255,35 @@ mod tests {
     use crate::{FmdKeyGen, KeyExpansion, KeyRandomization, MultiFmdScheme};
 
     #[test]
+    fn test_flagging_with_different_pks_flushes_cache() {
+        let mut csprng = rand_core::OsRng;
+
+        let mut compact_multi_fmd2 = MultiFmd2CompactScheme::new(10, 3);
+
+        let (_, master_cpk_1) = compact_multi_fmd2.generate_keys(&mut csprng);
+        let (_, master_cpk_2) = compact_multi_fmd2.generate_keys(&mut csprng);
+        assert_ne!(master_cpk_1.fingerprint, master_cpk_2.fingerprint);
+
+        _ = compact_multi_fmd2.flag(&master_cpk_1, &mut csprng);
+        assert_eq!(
+            compact_multi_fmd2.expanded_pk.as_ref().unwrap().fingerprint,
+            master_cpk_1.fingerprint
+        );
+
+        _ = compact_multi_fmd2.flag(&master_cpk_2, &mut csprng);
+        assert_eq!(
+            compact_multi_fmd2.expanded_pk.as_ref().unwrap().fingerprint,
+            master_cpk_2.fingerprint
+        );
+
+        _ = compact_multi_fmd2.flag(&master_cpk_1, &mut csprng);
+        assert_eq!(
+            compact_multi_fmd2.expanded_pk.as_ref().unwrap().fingerprint,
+            master_cpk_1.fingerprint
+        );
+    }
+
+    #[test]
     fn test_unique_flag_ciphertexts_for_same_pk() {
         let mut csprng = rand_core::OsRng;
 

--- a/polyfuzzy/src/fmd2_compact/mod.rs
+++ b/polyfuzzy/src/fmd2_compact/mod.rs
@@ -8,7 +8,9 @@ use serde::{Deserialize, Serialize};
 
 mod polynomial;
 use crate::{
-    fmd2_generic::{ChamaleonHashBasepoint, GenericFlagCiphertexts, GenericFmdPublicKey},
+    fmd2_generic::{
+        ChamaleonHashBasepoint, CiphertextBits, GenericFlagCiphertexts, GenericFmdPublicKey,
+    },
     FmdKeyGen, FmdSecretKey, KeyExpansion, KeyRandomization, MultiFmdScheme,
 };
 
@@ -76,6 +78,8 @@ pub struct MultiFmd2CompactScheme {
     pub(crate) public_scalars: Vec<Scalar>,
     /// The randomized public key.
     randomized_pk: Option<FmdPublicKey>,
+    /// Scratch buffer used to decompress flag ciphertext bits
+    ciphertext_bits: CiphertextBits,
 }
 
 impl MultiFmd2CompactScheme {
@@ -92,6 +96,7 @@ impl MultiFmd2CompactScheme {
             threshold,
             public_scalars,
             randomized_pk: None,
+            ciphertext_bits: CiphertextBits(Vec::with_capacity(gamma)),
         }
     }
 }
@@ -146,8 +151,12 @@ impl MultiFmdScheme<CompactPublicKey, FlagCiphertexts> for MultiFmd2CompactSchem
         flag
     }
 
-    fn detect(&self, detection_key: &crate::DetectionKey, flag_ciphers: &FlagCiphertexts) -> bool {
-        detection_key.detect(&flag_ciphers.0)
+    fn detect(
+        &mut self,
+        detection_key: &crate::DetectionKey,
+        flag_ciphers: &FlagCiphertexts,
+    ) -> bool {
+        detection_key.detect(&mut self.ciphertext_bits, &flag_ciphers.0)
     }
 }
 

--- a/polyfuzzy/src/fmd2_compact/polynomial.rs
+++ b/polyfuzzy/src/fmd2_compact/polynomial.rs
@@ -67,16 +67,7 @@ impl Polynomial {
     pub(crate) fn evaluate(&self, public_scalars: &[Scalar]) -> ScalarEvaluations {
         let evaluations = public_scalars
             .iter()
-            .map(|scalar| {
-                let mut res = self.coeffs[0];
-                let mut pow = Scalar::ONE;
-                for coeff in self.coeffs.iter().skip(1) {
-                    pow *= scalar;
-                    res += coeff * pow;
-                }
-
-                res
-            })
+            .map(|scalar| evaluate_scalar(scalar, &self.coeffs))
             .collect();
 
         ScalarEvaluations {
@@ -85,20 +76,27 @@ impl Polynomial {
     }
 }
 
+fn evaluate_scalar<C>(public_scalar: &Scalar, coeffs: &[C]) -> C
+where
+    C: Clone + core::ops::AddAssign,
+    for<'coeff> &'coeff C: core::ops::Mul<Scalar, Output = C>,
+{
+    let mut res = coeffs[0].clone();
+    let mut pow = Scalar::ONE;
+
+    for coeff in &coeffs[1..] {
+        pow *= public_scalar;
+        res += coeff * pow;
+    }
+
+    res
+}
+
 impl EncodedPolynomial {
     pub(crate) fn evaluate(&self, public_scalars: &[Scalar]) -> PointEvaluations {
         let evaluations = public_scalars
             .iter()
-            .map(|scalar| {
-                let mut res = self.coeffs[0];
-                let mut pow = Scalar::ONE;
-                for coeff in self.coeffs.iter().skip(1) {
-                    pow *= scalar;
-                    res += coeff * pow;
-                }
-
-                res
-            })
+            .map(|scalar| evaluate_scalar(scalar, &self.coeffs))
             .collect();
 
         PointEvaluations {

--- a/polyfuzzy/src/fmd2_compact/polynomial.rs
+++ b/polyfuzzy/src/fmd2_compact/polynomial.rs
@@ -37,9 +37,11 @@ impl Polynomial {
         degree: usize,
         rng: &mut R,
     ) -> Polynomial {
-        let coeffs: Vec<Scalar> = (0..degree + 1).map(|_| Scalar::random(rng)).collect();
-
-        Polynomial { coeffs }
+        Polynomial {
+            coeffs: core::iter::repeat_with(|| Scalar::random(rng))
+                .take(degree + 1)
+                .collect(),
+        }
     }
 
     pub(crate) fn encode(&self, basepoint: &RistrettoPoint) -> EncodedPolynomial {

--- a/polyfuzzy/src/lib.rs
+++ b/polyfuzzy/src/lib.rs
@@ -30,7 +30,7 @@ pub trait MultiFmdScheme<PK, F> {
     }
 
     /// Probabilistic detection based on the false-positive rate associated to `detection_key`.
-    fn detect(&self, detection_key: &DetectionKey, flag_ciphers: &F) -> bool;
+    fn detect(&mut self, detection_key: &DetectionKey, flag_ciphers: &F) -> bool;
 }
 
 /// A trait to generate the keypair of the FMD scheme.


### PR DESCRIPTION
- Refactor to improve code reutilization
- Optimize flag detection path
  - Keep a scratch buffer to decompress flag ciphertexts, reducing number of `CiphertextBits` allocations to one